### PR TITLE
Made the dependency on stdlib.h and assert.h optional

### DIFF
--- a/aarch64.c
+++ b/aarch64.c
@@ -2,8 +2,17 @@
 #include "libco.h"
 #include "settings.h"
 
-#include <assert.h>
-#include <stdlib.h>
+#if !defined(LIBCO_ASSERT)
+  #include <assert.h>
+  #define LIBCO_ASSERT(...) assert(__VA_ARGS__)
+#endif
+
+#if !defined(LIBCO_MALLOC) || !defined(LIBCO_FREE)
+  #include <stdlib.h>
+  #define LIBCO_MALLOC(...) malloc(__VA_ARGS__)
+  #define LIBCO_FREE(...)   free(__VA_ARGS__)
+#endif
+
 #include <stdint.h>
 #ifdef LIBCO_MPROTECT
   #include <unistd.h>
@@ -85,13 +94,13 @@ cothread_t co_derive(void* memory, unsigned int size, void (*entrypoint)(void)) 
 }
 
 cothread_t co_create(unsigned int size, void (*entrypoint)(void)) {
-  void* memory = malloc(size);
+  void* memory = LIBCO_MALLOC(size);
   if(!memory) return (cothread_t)0;
   return co_derive(memory, size, entrypoint);
 }
 
 void co_delete(cothread_t handle) {
-  free(handle);
+  LIBCO_FREE(handle);
 }
 
 void co_switch(cothread_t handle) {

--- a/aarch64.c
+++ b/aarch64.c
@@ -2,17 +2,6 @@
 #include "libco.h"
 #include "settings.h"
 
-#if !defined(LIBCO_ASSERT)
-  #include <assert.h>
-  #define LIBCO_ASSERT(...) assert(__VA_ARGS__)
-#endif
-
-#if !defined(LIBCO_MALLOC) || !defined(LIBCO_FREE)
-  #include <stdlib.h>
-  #define LIBCO_MALLOC(...) malloc(__VA_ARGS__)
-  #define LIBCO_FREE(...)   free(__VA_ARGS__)
-#endif
-
 #include <stdint.h>
 #ifdef LIBCO_MPROTECT
   #include <unistd.h>

--- a/amd64.c
+++ b/amd64.c
@@ -2,8 +2,16 @@
 #include "libco.h"
 #include "settings.h"
 
-#include <assert.h>
-#include <stdlib.h>
+#if !defined(LIBCO_ASSERT)
+  #include <assert.h>
+  #define LIBCO_ASSERT(...) assert(__VA_ARGS__)
+#endif
+
+#if !defined(LIBCO_MALLOC) || !defined(LIBCO_FREE)
+  #include <stdlib.h>
+  #define LIBCO_MALLOC(...) malloc(__VA_ARGS__)
+  #define LIBCO_FREE(...)   free(__VA_ARGS__)
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -114,7 +122,7 @@ static void (*co_swap)(cothread_t, cothread_t) = 0;
 #endif
 
 static void crash() {
-  assert(0);  /* called only if cothread_t entrypoint returns */
+  LIBCO_ASSERT(0);  /* called only if cothread_t entrypoint returns */
 }
 
 cothread_t co_active() {
@@ -142,13 +150,13 @@ cothread_t co_derive(void* memory, unsigned int size, void (*entrypoint)(void)) 
 }
 
 cothread_t co_create(unsigned int size, void (*entrypoint)(void)) {
-  void* memory = malloc(size);
+  void* memory = LIBCO_MALLOC(size);
   if(!memory) return (cothread_t)0;
   return co_derive(memory, size, entrypoint);
 }
 
 void co_delete(cothread_t handle) {
-  free(handle);
+  LIBCO_FREE(handle);
 }
 
 void co_switch(cothread_t handle) {

--- a/amd64.c
+++ b/amd64.c
@@ -2,17 +2,6 @@
 #include "libco.h"
 #include "settings.h"
 
-#if !defined(LIBCO_ASSERT)
-  #include <assert.h>
-  #define LIBCO_ASSERT(...) assert(__VA_ARGS__)
-#endif
-
-#if !defined(LIBCO_MALLOC) || !defined(LIBCO_FREE)
-  #include <stdlib.h>
-  #define LIBCO_MALLOC(...) malloc(__VA_ARGS__)
-  #define LIBCO_FREE(...)   free(__VA_ARGS__)
-#endif
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/arm.c
+++ b/arm.c
@@ -2,8 +2,17 @@
 #include "libco.h"
 #include "settings.h"
 
-#include <assert.h>
-#include <stdlib.h>
+#if !defined(LIBCO_ASSERT)
+  #include <assert.h>
+  #define LIBCO_ASSERT(...) assert(__VA_ARGS__)
+#endif
+
+#if !defined(LIBCO_MALLOC) || !defined(LIBCO_FREE)
+  #include <stdlib.h>
+  #define LIBCO_MALLOC(...) malloc(__VA_ARGS__)
+  #define LIBCO_FREE(...)   free(__VA_ARGS__)
+#endif
+
 #ifdef LIBCO_MPROTECT
   #include <unistd.h>
   #include <sys/mman.h>
@@ -61,13 +70,13 @@ cothread_t co_derive(void* memory, unsigned int size, void (*entrypoint)(void)) 
 }
 
 cothread_t co_create(unsigned int size, void (*entrypoint)(void)) {
-  void* memory = malloc(size);
+  void* memory = LIBCO_MALLOC(size);
   if(!memory) return (cothread_t)0;
   return co_derive(memory, size, entrypoint);
 }
 
 void co_delete(cothread_t handle) {
-  free(handle);
+  LIBCO_FREE(handle);
 }
 
 void co_switch(cothread_t handle) {

--- a/arm.c
+++ b/arm.c
@@ -2,17 +2,6 @@
 #include "libco.h"
 #include "settings.h"
 
-#if !defined(LIBCO_ASSERT)
-  #include <assert.h>
-  #define LIBCO_ASSERT(...) assert(__VA_ARGS__)
-#endif
-
-#if !defined(LIBCO_MALLOC) || !defined(LIBCO_FREE)
-  #include <stdlib.h>
-  #define LIBCO_MALLOC(...) malloc(__VA_ARGS__)
-  #define LIBCO_FREE(...)   free(__VA_ARGS__)
-#endif
-
 #ifdef LIBCO_MPROTECT
   #include <unistd.h>
   #include <sys/mman.h>

--- a/ppc.c
+++ b/ppc.c
@@ -4,12 +4,6 @@
 #include "libco.h"
 #include "settings.h"
 
-#if !defined(LIBCO_MALLOC) || !defined(LIBCO_FREE)
-  #include <stdlib.h>
-  #define LIBCO_MALLOC(...) malloc(__VA_ARGS__)
-  #define LIBCO_FREE(...)   free(__VA_ARGS__)
-#endif
-
 #include <stdint.h>
 #include <string.h>
 

--- a/ppc.c
+++ b/ppc.c
@@ -4,7 +4,12 @@
 #include "libco.h"
 #include "settings.h"
 
-#include <stdlib.h>
+#if !defined(LIBCO_MALLOC) || !defined(LIBCO_FREE)
+  #include <stdlib.h>
+  #define LIBCO_MALLOC(...) malloc(__VA_ARGS__)
+  #define LIBCO_FREE(...)   free(__VA_ARGS__)
+#endif
+
 #include <stdint.h>
 #include <string.h>
 
@@ -327,7 +332,7 @@ cothread_t co_derive(void* memory, unsigned int size, void (*entry_)(void)) {
 static uint32_t* co_create_(unsigned size, uintptr_t entry) {
   (void)entry;
 
-  uint32_t* t = (uint32_t*)malloc(size);
+  uint32_t* t = (uint32_t*)LIBCO_MALLOC(size);
 
   #if LIBCO_PPCDESC
   if(t) {
@@ -390,7 +395,7 @@ cothread_t co_create(unsigned int size, void (*entry_)(void)) {
 }
 
 void co_delete(cothread_t t) {
-  free(t);
+  LIBCO_FREE(t);
 }
 
 static void co_init_(void) {

--- a/ppc64v2.c
+++ b/ppc64v2.c
@@ -6,12 +6,6 @@
 
 #include <stdint.h>
 
-#if !defined(LIBCO_MALLOC) || !defined(LIBCO_FREE)
-  #include <stdlib.h>
-  #define LIBCO_MALLOC(...) malloc(__VA_ARGS__)
-  #define LIBCO_FREE(...)   free(__VA_ARGS__)
-#endif
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/ppc64v2.c
+++ b/ppc64v2.c
@@ -5,7 +5,12 @@
 #include "settings.h"
 
 #include <stdint.h>
-#include <stdlib.h>
+
+#if !defined(LIBCO_MALLOC) || !defined(LIBCO_FREE)
+  #include <stdlib.h>
+  #define LIBCO_MALLOC(...) malloc(__VA_ARGS__)
+  #define LIBCO_FREE(...)   free(__VA_ARGS__)
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -223,7 +228,7 @@ __asm__(
 
 cothread_t co_active() {
   if(!co_active_handle) {
-    co_active_handle = (struct ppc64_context*)malloc(MIN_STACK + sizeof(struct ppc64_context));
+    co_active_handle = (struct ppc64_context*)LIBCO_MALLOC(MIN_STACK + sizeof(struct ppc64_context));
   }
   return (cothread_t)co_active_handle;
 }
@@ -255,13 +260,13 @@ cothread_t co_derive(void* memory, unsigned int size, void (*coentry)(void)) {
 }
 
 cothread_t co_create(unsigned int size, void (*coentry)(void)) {
-  void* memory = malloc(size);
+  void* memory = LIBCO_MALLOC(size);
   if(!memory) return (cothread_t)0;
   return co_derive(memory, size, coentry);
 }
 
 void co_delete(cothread_t handle) {
-  free(handle);
+  LIBCO_FREE(handle);
 }
 
 void co_switch(cothread_t to) {

--- a/settings.h
+++ b/settings.h
@@ -26,6 +26,17 @@
   #define alignas(bytes)
 #endif
 
+#if !defined(LIBCO_ASSERT)
+  #include <assert.h>
+  #define LIBCO_ASSERT assert
+#endif
+
+#if !defined(LIBCO_MALLOC) || !defined(LIBCO_FREE)
+  #include <stdlib.h>
+  #define LIBCO_MALLOC malloc
+  #define LIBCO_FREE   free
+#endif
+
 #if defined(_MSC_VER)
   #define section(name) __declspec(allocate("." #name))
 #elif defined(__APPLE__)
@@ -33,6 +44,7 @@
 #else
   #define section(name) __attribute__((section("." #name "#")))
 #endif
+
 
 /* if defined(LIBCO_C) */
 #endif

--- a/x86.c
+++ b/x86.c
@@ -2,8 +2,16 @@
 #include "libco.h"
 #include "settings.h"
 
-#include <assert.h>
-#include <stdlib.h>
+#if !defined(LIBCO_ASSERT)
+  #include <assert.h>
+  #define LIBCO_ASSERT(...) assert(__VA_ARGS__)
+#endif
+
+#if !defined(LIBCO_MALLOC) || !defined(LIBCO_FREE)
+  #include <stdlib.h>
+  #define LIBCO_MALLOC(...) malloc(__VA_ARGS__)
+  #define LIBCO_FREE(...)   free(__VA_ARGS__)
+#endif
 
 #ifdef __cplusplus
 extern "C" {
@@ -68,7 +76,7 @@ static const unsigned char co_swap_function[4096] = {
 #endif
 
 static void crash() {
-  assert(0);  /* called only if cothread_t entrypoint returns */
+  LIBCO_ASSERT(0);  /* called only if cothread_t entrypoint returns */
 }
 
 cothread_t co_active() {
@@ -96,13 +104,13 @@ cothread_t co_derive(void* memory, unsigned int size, void (*entrypoint)(void)) 
 }
 
 cothread_t co_create(unsigned int size, void (*entrypoint)(void)) {
-  void* memory = malloc(size);
+  void* memory = LIBCO_MALLOC(size);
   if(!memory) return (cothread_t)0;
   return co_derive(memory, size, entrypoint);
 }
 
 void co_delete(cothread_t handle) {
-  free(handle);
+  LIBCO_FREE(handle);
 }
 
 void co_switch(cothread_t handle) {

--- a/x86.c
+++ b/x86.c
@@ -2,17 +2,6 @@
 #include "libco.h"
 #include "settings.h"
 
-#if !defined(LIBCO_ASSERT)
-  #include <assert.h>
-  #define LIBCO_ASSERT(...) assert(__VA_ARGS__)
-#endif
-
-#if !defined(LIBCO_MALLOC) || !defined(LIBCO_FREE)
-  #include <stdlib.h>
-  #define LIBCO_MALLOC(...) malloc(__VA_ARGS__)
-  #define LIBCO_FREE(...)   free(__VA_ARGS__)
-#endif
-
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
This PR will make it possible for users to provide their own `malloc()`, `free()` and `assert()` wrappers. This means that using this library on Windows (if one plans on shipping without MSVCRT Redist) or on embedded  platforms (without a libc) will be easier.

The dependency on `mman.h`, `windows.h` and `unistd.h` are not touched, since I can't see why one might not want to use them on the relevant platforms. `stdint.h` is also left in since it only provides type definitions and not any functions.

The dependencies are still mandatory in the following files:
1. `sjlj.c`: `setjmp`/`longjmp` are libc features anyway
2. `ucontext.c`: No reason not to link to libc on POSIX systems
3. `ppc.c`: Still uses `string.h` for `memcpy`. Since `memcpy` is usually a compiler intrinsic with some spec-mandated magical behaviour, not sure if it's technically safe to override it.