### PR TITLE
Fix Clang's -Wstrict-prototypes warning

### DIFF
--- a/libco.h
+++ b/libco.h
@@ -13,12 +13,12 @@ extern "C" {
 
 typedef void* cothread_t;
 
-cothread_t co_active();
+cothread_t co_active(void);
 cothread_t co_derive(void*, unsigned int, void (*)(void));
 cothread_t co_create(unsigned int, void (*)(void));
 void co_delete(cothread_t);
 void co_switch(cothread_t);
-int co_serializable();
+int co_serializable(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Clang's `-Weverything` flags results in the following warnings:

```
/code/include/libkhadi/libco/libco.h:16:21: error: this function declaration is not a prototype
      [-Werror,-Wstrict-prototypes]
cothread_t co_active();
                    ^
                     void
/code/include/libkhadi/libco/libco.h:21:20: error: this function declaration is not a prototype
      [-Werror,-Wstrict-prototypes]
int co_serializable();
                   ^
                    void

```

This PR fixes this warning.