### PR TITLE
Use parentheses around assignments used as truth values

### DIFF
--- a/aarch64.c
+++ b/aarch64.c
@@ -71,7 +71,7 @@ cothread_t co_derive(void* memory, unsigned int size, void (*entrypoint)(void)) 
   }
   if(!co_active_handle) co_active_handle = &co_active_buffer;
 
-  if(handle = (unsigned long*)memory) {
+  if((handle = (unsigned long*)memory)) {
     unsigned int offset = (size & ~15);
     unsigned long* p = (unsigned long*)((unsigned char*)handle + offset);
     handle[0]  = (unsigned long)p;           /* x16 (stack pointer) */

--- a/amd64.c
+++ b/amd64.c
@@ -127,7 +127,7 @@ cothread_t co_derive(void* memory, unsigned int size, void (*entrypoint)(void)) 
   }
   if(!co_active_handle) co_active_handle = &co_active_buffer;
 
-  if(handle = (cothread_t)memory) {
+  if((handle = (cothread_t)memory)) {
     unsigned int offset = (size & ~15) - 32;
     long long *p = (long long*)((char*)handle + offset);  /* seek to top of stack */
     *--p = (long long)crash;                              /* crash if entrypoint returns */

--- a/arm.c
+++ b/arm.c
@@ -48,7 +48,7 @@ cothread_t co_derive(void* memory, unsigned int size, void (*entrypoint)(void)) 
   }
   if(!co_active_handle) co_active_handle = &co_active_buffer;
 
-  if(handle = (unsigned long*)memory) {
+  if((handle = (unsigned long*)memory)) {
     unsigned int offset = (size & ~15);
     unsigned long* p = (unsigned long*)((unsigned char*)handle + offset);
     handle[8] = (unsigned long)p;

--- a/x86.c
+++ b/x86.c
@@ -81,7 +81,7 @@ cothread_t co_derive(void* memory, unsigned int size, void (*entrypoint)(void)) 
   }
   if(!co_active_handle) co_active_handle = &co_active_buffer;
 
-  if(handle = (cothread_t)memory) {
+  if((handle = (cothread_t)memory)) {
     unsigned int offset = (size & ~15) - 32;
     long *p = (long*)((char*)handle + offset);  /* seek to top of stack */
     *--p = (long)crash;                         /* crash if entrypoint returns */


### PR DESCRIPTION
This pull request fixes an annoying compiler warning:
`libco/amd64.c:130:6: warning: suggest parentheses around assignment used as truth value [-Wparentheses]`

Tested and works great.