### PR TITLE
stack 16-byte alignment fix for arm/x86 versions

### DIFF
--- a/aarch64.c
+++ b/aarch64.c
@@ -76,8 +76,9 @@ cothread_t co_derive(void* memory, unsigned int size, void (*entrypoint)(void)) 
   VALGRIND_STACK_REGISTER(memory, memory + size);
 
   if((handle = (unsigned long*)memory)) {
-    unsigned int offset = (size & ~15);
-    unsigned long* p = (unsigned long*)((unsigned char*)handle + offset);
+    unsigned long stack_top = (unsigned long)handle + size;
+    stack_top &= ~((unsigned long) 15);
+    unsigned long *p = (unsigned long*)(stack_top);
     handle[0]  = (unsigned long)p;           /* x16 (stack pointer) */
     handle[1]  = (unsigned long)entrypoint;  /* x30 (link register) */
     handle[12] = (unsigned long)p;           /* x29 (frame pointer) */

--- a/amd64.c
+++ b/amd64.c
@@ -138,11 +138,13 @@ cothread_t co_derive(void* memory, unsigned int size, void (*entrypoint)(void)) 
   #endif
 
   if((handle = (cothread_t)memory)) {
-    unsigned int offset = (size & ~15) - 32;
-    long long *p = (long long*)((char*)handle + offset);  /* seek to top of stack */
-    *--p = (long long)crash;                              /* crash if entrypoint returns */
-    *--p = (long long)entrypoint;                         /* start of function */
-    *(long long*)handle = (long long)p;                   /* stack pointer */
+    unsigned long long stack_top = (unsigned long long)handle + size;
+    stack_top -= 32;
+    stack_top &= ~((unsigned long long) 15);
+    long long *p = (long long*)(stack_top);  /* seek to top of stack */
+    *--p = (long long)crash;                 /* crash if entrypoint returns */
+    *--p = (long long)entrypoint;            /* start of function */
+    *(long long*)handle = (long long)p;      /* stack pointer */
   }
 
   return handle;

--- a/arm.c
+++ b/arm.c
@@ -52,8 +52,9 @@ cothread_t co_derive(void* memory, unsigned int size, void (*entrypoint)(void)) 
   VALGRIND_STACK_REGISTER(memory, memory + size);
 
   if((handle = (unsigned long*)memory)) {
-    unsigned int offset = (size & ~15);
-    unsigned long* p = (unsigned long*)((unsigned char*)handle + offset);
+    unsigned long stack_top = (unsigned long)handle + size;
+    stack_top &= ~((unsigned long) 15);
+    unsigned long *p = (unsigned long*)(stack_top);
     handle[8] = (unsigned long)p;
     handle[9] = (unsigned long)entrypoint;
   }

--- a/x86.c
+++ b/x86.c
@@ -94,11 +94,13 @@ cothread_t co_derive(void* memory, unsigned int size, void (*entrypoint)(void)) 
   #endif
 
   if((handle = (cothread_t)memory)) {
-    unsigned int offset = (size & ~15) - 32;
-    long *p = (long*)((char*)handle + offset);  /* seek to top of stack */
-    *--p = (long)crash;                         /* crash if entrypoint returns */
-    *--p = (long)entrypoint;                    /* start of function */
-    *(long*)handle = (long)p;                   /* stack pointer */
+    unsigned long stack_top = (unsigned long)handle + size;
+    stack_top -= 32;
+    stack_top &= ~((unsigned long) 15);
+    long *p = (long*)(stack_top);  /* seek to top of stack */
+    *--p = (long)crash;            /* crash if entrypoint returns */
+    *--p = (long)entrypoint;       /* start of function */
+    *(long*)handle = (long)p;      /* stack pointer */
   }
 
   return handle;


### PR DESCRIPTION
should fix #32 form arm/x86 variants, but unfortunately only actually tested on amd64 platform (others only compilable and by plausibility)