### PR TITLE
Fix -Werror=stricter-prototypes

### DIFF
--- a/aarch64.c
+++ b/aarch64.c
@@ -49,7 +49,7 @@ static const uint32_t co_swap_function[1024] = {
   0xd61f03c0,  /* br x30               */
 };
 
-static void co_init() {
+static void co_init(void) {
   #ifdef LIBCO_MPROTECT
   unsigned long addr = (unsigned long)co_swap_function;
   unsigned long base = addr - (addr % sysconf(_SC_PAGESIZE));
@@ -58,7 +58,7 @@ static void co_init() {
   #endif
 }
 
-cothread_t co_active() {
+cothread_t co_active(void) {
   if(!co_active_handle) co_active_handle = &co_active_buffer;
   return co_active_handle;
 }
@@ -97,7 +97,7 @@ void co_switch(cothread_t handle) {
   co_swap(co_active_handle = handle, co_previous_handle);
 }
 
-int co_serializable() {
+int co_serializable(void) {
   return 1;
 }
 

--- a/amd64.c
+++ b/amd64.c
@@ -68,7 +68,7 @@ static void (*co_swap)(cothread_t, cothread_t) = 0;
 
   #include <windows.h>
 
-  static void co_init() {
+  static void co_init(void) {
     #ifdef LIBCO_MPROTECT
     DWORD old_privileges;
     VirtualProtect((void*)co_swap_function, sizeof co_swap_function, PAGE_EXECUTE_READ, &old_privileges);
@@ -100,7 +100,7 @@ static void (*co_swap)(cothread_t, cothread_t) = 0;
     #include <sys/mman.h>
   #endif
 
-  static void co_init() {
+  static void co_init(void) {
     #ifdef LIBCO_MPROTECT
     unsigned long long addr = (unsigned long long)co_swap_function;
     unsigned long long base = addr - (addr % sysconf(_SC_PAGESIZE));
@@ -110,11 +110,11 @@ static void (*co_swap)(cothread_t, cothread_t) = 0;
   }
 #endif
 
-static void crash() {
+static void crash(void) {
   LIBCO_ASSERT(0);  /* called only if cothread_t entrypoint returns */
 }
 
-cothread_t co_active() {
+cothread_t co_active(void) {
   if(!co_active_handle) co_active_handle = &co_active_buffer;
   return co_active_handle;
 }
@@ -153,7 +153,7 @@ void co_switch(cothread_t handle) {
   co_swap(co_active_handle = handle, co_previous_handle);
 }
 
-int co_serializable() {
+int co_serializable(void) {
   return 1;
 }
 

--- a/arm.c
+++ b/arm.c
@@ -26,7 +26,7 @@ static const unsigned long co_swap_function[1024] = {
   0xe12fff1e,  /* bx lr                     */
 };
 
-static void co_init() {
+static void co_init(void) {
   #ifdef LIBCO_MPROTECT
   unsigned long addr = (unsigned long)co_swap_function;
   unsigned long base = addr - (addr % sysconf(_SC_PAGESIZE));
@@ -35,7 +35,7 @@ static void co_init() {
   #endif
 }
 
-cothread_t co_active() {
+cothread_t co_active(void) {
   if(!co_active_handle) co_active_handle = &co_active_buffer;
   return co_active_handle;
 }
@@ -73,7 +73,7 @@ void co_switch(cothread_t handle) {
   co_swap(co_active_handle = handle, co_previous_handle);
 }
 
-int co_serializable() {
+int co_serializable(void) {
   return 1;
 }
 

--- a/doc/usage.md
+++ b/doc/usage.md
@@ -39,7 +39,7 @@ to make a whole new port.
 ```c
 typedef void* cothread_t;
 
-cothread_t co_active();
+cothread_t co_active(void);
 cothread_t co_create(unsigned int heapsize, void (*coentry)(void));
 void       co_delete(cothread_t cothread);
 void       co_switch(cothread_t cothread);
@@ -60,7 +60,7 @@ state to which the execution can be co_switch()ed to.
 
 ## co_active
 ```c
-cothread_t co_active();
+cothread_t co_active(void);
 ```
 Return handle to current cothread.
 

--- a/fiber.c
+++ b/fiber.c
@@ -16,7 +16,7 @@ static void __stdcall co_thunk(void* coentry) {
   ((void (*)(void))coentry)();
 }
 
-cothread_t co_active() {
+cothread_t co_active(void) {
   if(!co_active_) {
     ConvertThreadToFiber(0);
     co_active_ = GetCurrentFiber();
@@ -46,7 +46,7 @@ void co_switch(cothread_t cothread) {
   SwitchToFiber(cothread);
 }
 
-int co_serializable() {
+int co_serializable(void) {
   return 0;
 }
 

--- a/ppc.c
+++ b/ppc.c
@@ -412,7 +412,7 @@ static void co_init_(void) {
   co_active_handle = co_create_(state_size, (uintptr_t)&co_switch);
 }
 
-cothread_t co_active() {
+cothread_t co_active(void) {
   if(!co_active_handle) co_init_();
 
   return co_active_handle;
@@ -425,6 +425,6 @@ void co_switch(cothread_t t) {
   CO_SWAP_ASM(t, old);
 }
 
-int co_serializable() {
+int co_serializable(void) {
   return 0;
 }

--- a/ppc64v2.c
+++ b/ppc64v2.c
@@ -220,7 +220,7 @@ __asm__(
   ".size swap_context, .-swap_context\n"
 );
 
-cothread_t co_active() {
+cothread_t co_active(void) {
   if(!co_active_handle) {
     co_active_handle = (struct ppc64_context*)LIBCO_MALLOC(MIN_STACK + sizeof(struct ppc64_context));
   }
@@ -269,7 +269,7 @@ void co_switch(cothread_t to) {
   swap_context((struct ppc64_context*)to, from);
 }
 
-int co_serializable() {
+int co_serializable(void) {
   return 1;
 }
 

--- a/sjlj.c
+++ b/sjlj.c
@@ -33,7 +33,7 @@ static void springboard(int ignored) {
   }
 }
 
-cothread_t co_active() {
+cothread_t co_active(void) {
   if(!co_running) co_running = &co_primary;
   return (cothread_t)co_running;
 }
@@ -136,7 +136,7 @@ void co_switch(cothread_t cothread) {
   }
 }
 
-int co_serializable() {
+int co_serializable(void) {
   return 0;
 }
 

--- a/ucontext.c
+++ b/ucontext.c
@@ -26,7 +26,7 @@ extern "C" {
 static thread_local ucontext_t co_primary;
 static thread_local ucontext_t* co_running = 0;
 
-cothread_t co_active() {
+cothread_t co_active(void) {
   if(!co_running) co_running = &co_primary;
   return (cothread_t)co_running;
 }
@@ -77,7 +77,7 @@ void co_switch(cothread_t cothread) {
   swapcontext(old_thread, co_running);
 }
 
-int co_serializable() {
+int co_serializable(void) {
   return 0;
 }
 

--- a/x86.c
+++ b/x86.c
@@ -42,7 +42,7 @@ static const unsigned char co_swap_function[4096] = {
 #ifdef _WIN32
   #include <windows.h>
 
-  static void co_init() {
+  static void co_init(void) {
     #ifdef LIBCO_MPROTECT
     DWORD old_privileges;
     VirtualProtect((void*)co_swap_function, sizeof co_swap_function, PAGE_EXECUTE_READ, &old_privileges);
@@ -54,7 +54,7 @@ static const unsigned char co_swap_function[4096] = {
     #include <sys/mman.h>
   #endif
 
-  static void co_init() {
+  static void co_init(void) {
     #ifdef LIBCO_MPROTECT
     unsigned long addr = (unsigned long)co_swap_function;
     unsigned long base = addr - (addr % sysconf(_SC_PAGESIZE));
@@ -64,11 +64,11 @@ static const unsigned char co_swap_function[4096] = {
   }
 #endif
 
-static void crash() {
+static void crash(void) {
   LIBCO_ASSERT(0);  /* called only if cothread_t entrypoint returns */
 }
 
-cothread_t co_active() {
+cothread_t co_active(void) {
   if(!co_active_handle) co_active_handle = &co_active_buffer;
   return co_active_handle;
 }
@@ -107,7 +107,7 @@ void co_switch(cothread_t handle) {
   co_swap(co_active_handle = handle, co_previous_handle);
 }
 
-int co_serializable() {
+int co_serializable(void) {
   return 1;
 }
 


### PR DESCRIPTION
This is needed for upcoming gcc and clang versions.

Reference: https://archives.gentoo.org/gentoo-dev/message/dd9f2d3082b8b6f8dfbccb0639e6e240