### PR TITLE
Add Github Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,52 @@ jobs:
             ./valgrind-wrapper.sh --expect-failure ./test_timing
           fi
 
+  build-windows:
+    name: Windows (${{ matrix.arch }})
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [amd64, x86]
+    steps:
+      - uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: ${{ matrix.arch }}
+      - uses: actions/checkout@v3
+      - name: Build
+        working-directory: doc/examples
+        run: |
+          # __STDC__ required for `alignas` (or using /Za)
+          cl /I ../.. /D LIBCO_MPROTECT /Zc:__STDC__ /c ../../libco.c
+          cl /I ../.. test_args.cpp libco.obj
+          cl /I ../.. test_timing.cpp libco.obj
+          # Skip test_serialization that uses sys/mman.h
+      - name: Run examples
+        working-directory: doc/examples
+        run: |
+          ./test_args.exe
+          ./test_timing.exe
+
+  build-windows-fibers:
+    name: Windows (fibers)
+    runs-on: windows-latest
+    steps:
+      - uses: ilammy/msvc-dev-cmd@v1
+      - uses: actions/checkout@v3
+      - name: Build
+        working-directory: doc/examples
+        run: |
+          # __STDC__ required for `alignas` (or using /Za)
+          cl /I ../.. /D LIBCO_MPROTECT /Zc:__STDC__ /Folibco /c ../../fiber.c
+          cl /I ../.. test_args.cpp libco.obj
+          cl /I ../.. test_timing.cpp libco.obj
+          # Skip test_serialization that uses sys/mman.h
+      - name: Run examples
+        working-directory: doc/examples
+        run: |
+          ./test_args.exe
+          ./test_timing.exe
+
   sanitizers:
     name: ${{ matrix.sanitizer }}-sanitizer
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,9 +36,7 @@ jobs:
         run: |
           ./test_args
           ./test_timing
-          if ./test_serialization ; then
-            (echo "Expected test_serialization to fail"; exit 98)
-          fi
+          ./test_serialization
       - name: Run valgrind
         working-directory: doc/examples
         run: |
@@ -68,20 +66,12 @@ jobs:
           install: |
             apt-get update -q -y
             apt-get install -q -y --no-install-recommends build-essential valgrind
-          env: |
-            target: ${{ matrix.target }}
           run: |
             cd doc/examples
             ./build.sh
             ./test_args
             ./test_timing
-            if [ "$target" == "arm" ]; then
-              if ./test_serialization ; then
-                (echo "Expected test_serialization to fail"; exit 98)
-              fi
-            else
-              ./test_serialization
-            fi
+            ./test_serialization
             ./valgrind-wrapper.sh --expect-failure ./test_args
             ./valgrind-wrapper.sh --expect-failure ./test_serialization
             # test_timing not run with valgrind on qemu since it's very slow.
@@ -151,12 +141,13 @@ jobs:
           cl /I ../.. /D LIBCO_MPROTECT /Zc:__STDC__ /c ../../libco.c
           cl /I ../.. test_args.cpp libco.obj
           cl /I ../.. test_timing.cpp libco.obj
-          # Skip test_serialization that uses sys/mman.h
+          cl /I ../.. test_serialization.cpp libco.obj
       - name: Run examples
         working-directory: doc/examples
         run: |
           ./test_args.exe
           ./test_timing.exe
+          ./test_serialization
 
   build-windows-fibers:
     name: Windows (fibers)
@@ -171,7 +162,7 @@ jobs:
           cl /I ../.. /D LIBCO_MPROTECT /Zc:__STDC__ /Folibco /c ../../fiber.c
           cl /I ../.. test_args.cpp libco.obj
           cl /I ../.. test_timing.cpp libco.obj
-          # Skip test_serialization that uses sys/mman.h
+          # Serialization not supported
       - name: Run examples
         working-directory: doc/examples
         run: |
@@ -201,7 +192,4 @@ jobs:
           clang++ $FLAGS -o test_serialization libco.o test_serialization.o
           ./test_args
           ./test_timing
-          if ./test_serialization ; then
-            # ASan don't like mmap() with MAP_FIXED
-            (echo "Expected test_serialization to fail"; exit 98)
-          fi
+          ./test_serialization

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,161 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    name: ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: amd64
+            flags: -O3 -fomit-frame-pointer
+          - target: x86
+            flags: -m32 -O3 -fomit-frame-pointer
+    steps:
+      - uses: actions/checkout@v3
+      - name: Prepare
+        run: |
+          sudo dpkg --add-architecture i386
+          sudo apt-get update -q -y
+          sudo apt-get install -y gcc-multilib g++-multilib valgrind libc6-dbg libc6-dbg:i386
+      - name: Build
+        working-directory: doc/examples
+        run: |
+          cc ${{ matrix.flags }} -I../.. -o libco.o -c ../../libco.c
+          c++ ${{ matrix.flags }} -I../.. -c test_timing.cpp
+          c++ ${{ matrix.flags }} -o test_timing libco.o test_timing.o
+          c++ ${{ matrix.flags }} -I../.. -c test_args.cpp
+          c++ ${{ matrix.flags }} -o test_args libco.o test_args.o
+          c++ ${{ matrix.flags }} -I../.. -c test_serialization.cpp
+          c++ ${{ matrix.flags }} -o test_serialization libco.o test_serialization.o
+      - name: Run examples
+        working-directory: doc/examples
+        run: |
+          ./test_args
+          ./test_timing
+          if ./test_serialization ; then
+            (echo "Expected test_serialization to fail"; exit 98)
+          fi
+      - name: Run valgrind
+        working-directory: doc/examples
+        run: |
+          ./valgrind-wrapper.sh --expect-failure ./test_args
+          ./valgrind-wrapper.sh --expect-failure ./test_timing
+          ./valgrind-wrapper.sh --expect-failure ./test_serialization
+
+  build-qemu:
+    name: ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: arm
+            arch: armv7
+          - target: aarch64
+            arch: aarch64
+          - target: ppc64v2
+            arch: ppc64le
+    steps:
+      - uses: actions/checkout@v3
+      - uses: uraimo/run-on-arch-action@v2
+        with:
+          arch: ${{ matrix.arch }}
+          distro: ubuntu_latest
+          install: |
+            apt-get update -q -y
+            apt-get install -q -y --no-install-recommends build-essential valgrind
+          env: |
+            target: ${{ matrix.target }}
+          run: |
+            cd doc/examples
+            ./build.sh
+            ./test_args
+            ./test_timing
+            if [ "$target" == "arm" ]; then
+              if ./test_serialization ; then
+                (echo "Expected test_serialization to fail"; exit 98)
+              fi
+            else
+              ./test_serialization
+            fi
+            ./valgrind-wrapper.sh --expect-failure ./test_args
+            ./valgrind-wrapper.sh --expect-failure ./test_serialization
+            # test_timing not run with valgrind on qemu since it's very slow.
+
+  build-posix:
+    name: ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: setjmp
+            file: sjlj.c
+            defines: -D_FORTIFY_SOURCE=0
+          - target: ucontext
+            file: ucontext.c
+            defines:
+    steps:
+      - uses: actions/checkout@v3
+      - name: Prepare
+        run: |
+          sudo apt-get install -y valgrind
+      - name: Build
+        working-directory: doc/examples
+        env:
+          FLAGS: -O3 -fomit-frame-pointer
+        run: |
+          cc ${{ matrix.defines }} $FLAGS -I../.. -o libco.o -c ../../${{ matrix.file }}
+          c++ $FLAGS -I../.. -c test_timing.cpp
+          c++ $FLAGS -o test_timing libco.o test_timing.o
+          c++ $FLAGS -I../.. -c test_args.cpp
+          c++ $FLAGS -o test_args libco.o test_args.o
+          # Serialization not supported
+      - name: Run examples
+        working-directory: doc/examples
+        run: |
+          ./test_args
+          # test_timing not run for ucontext since it's very slow.
+          if [ "${{ matrix.target }}" != "ucontext" ]; then
+            ./test_timing
+          fi
+      - name: Run valgrind
+        working-directory: doc/examples
+        run: |
+          ./valgrind-wrapper.sh --expect-failure ./test_args
+          # test_timing not run for ucontext since it's very slow.
+          if [ "${{ matrix.target }}" != "ucontext" ]; then
+            ./valgrind-wrapper.sh --expect-failure ./test_timing
+          fi
+
+  sanitizers:
+    name: ${{ matrix.sanitizer }}-sanitizer
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [thread, undefined, leak, address]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Build and run examples
+        working-directory: doc/examples
+        env:
+          FLAGS: -fsanitize=${{ matrix.sanitizer }} -fno-sanitize-recover=all -fno-omit-frame-pointer
+        run: |
+          clang $FLAGS -I../.. -o libco.o -c ../../libco.c
+          clang++ $FLAGS -I../.. -c test_timing.cpp
+          clang++ $FLAGS -o test_timing libco.o test_timing.o
+          clang++ $FLAGS -I../.. -c test_args.cpp
+          clang++ $FLAGS -o test_args libco.o test_args.o
+          clang++ $FLAGS -I../.. -c test_serialization.cpp
+          clang++ $FLAGS -o test_serialization libco.o test_serialization.o
+          ./test_args
+          ./test_timing
+          if ./test_serialization ; then
+            # ASan don't like mmap() with MAP_FIXED
+            (echo "Expected test_serialization to fail"; exit 98)
+          fi

--- a/doc/examples/build.sh
+++ b/doc/examples/build.sh
@@ -3,6 +3,6 @@ c++ -O3 -fomit-frame-pointer -I../.. -c test_timing.cpp
 c++ -O3 -fomit-frame-pointer -o test_timing libco.o test_timing.o
 c++ -O3 -fomit-frame-pointer -I../.. -c test_args.cpp
 c++ -O3 -fomit-frame-pointer -o test_args libco.o test_args.o
-c++ -O3 -fomit-frame-pointer -I../.. -c test_serialization.cpp
+c++ -O3 -fomit-frame-pointer -std=c++11 -I../.. -c test_serialization.cpp
 c++ -O3 -fomit-frame-pointer -o test_serialization libco.o test_serialization.o
 rm -f *.o

--- a/doc/examples/test_args.cpp
+++ b/doc/examples/test_args.cpp
@@ -69,8 +69,5 @@ int main() {
   co_switch(thread[1]);
 
   printf("\ndone\n");
-#if defined(_MSC_VER) || defined(__DJGPP__)
-  getch();
-#endif
   return 0;
 }

--- a/doc/examples/test_serialization.cpp
+++ b/doc/examples/test_serialization.cpp
@@ -1,6 +1,5 @@
 #include "test.h"
 #include <stdint.h>
-#include <sys/mman.h>
 
 namespace Thread {
   cothread_t host;
@@ -80,11 +79,7 @@ auto main() -> int {
     return 1;
   }
 
-  Memory::buffer = (uint8_t*)mmap(
-    (void*)0x10'0000'0000, 2 * 65536,
-    PROT_READ | PROT_WRITE | PROT_EXEC,
-    MAP_FIXED | MAP_PRIVATE | MAP_ANONYMOUS, -1, 0
-  );
+  Memory::buffer = (uint8_t*)malloc(2 * 65536);
   Memory::buffer[0] = 42;
   printf("%p (%u)\n", Memory::buffer, Memory::buffer[0]);
 
@@ -112,6 +107,6 @@ auto main() -> int {
 
   Thread::cpu = nullptr;
   Thread::apu = nullptr;
-  munmap((void*)0x900000000, 2 * 65536);
+  free(Memory::buffer);
   return 0;
 }

--- a/doc/examples/valgrind-wrapper.sh
+++ b/doc/examples/valgrind-wrapper.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+FAILURE=99
+SUCCESS=0
+
+expect_failure=0
+if [ "$1" = "--expect-failure" ]; then
+    expect_failure=1
+    shift
+fi
+
+valgrind --error-exitcode="$FAILURE" --log-file="valgrind.log" "$@"
+exitcode=$?
+# Report the log messages just in case there was anything interesting
+cat "valgrind.log" >&2
+
+if [ "$exitcode" -eq "$SUCCESS" ]; then
+    # Valgrind didn't reject our code, but if it warned
+    # about stack-switching, we care about that too.
+    # None of our tests should use enough stack
+    # to trigger this by accident.
+    if grep -qlF "Warning: client switching stacks?" "valgrind.log"; then
+        echo "Test confused Valgrind by switching stacks" >&2
+        exitcode=$FAILURE
+    fi
+fi
+
+if [ "$expect_failure" -eq 1 ]; then
+    if [ "$exitcode" -eq "$SUCCESS" ]; then
+        echo "Test passed, but was expected to fail?" >&2
+        exitcode=$FAILURE
+    else
+        echo "Task failed as expected" >&2
+        exitcode=$SUCCESS
+    fi
+fi
+
+exit "$exitcode"


### PR DESCRIPTION
Adds CI builds and test runs for all backends except `ppc.c`.

The test examples are run with `valgrind` where possible and the problems found are added as comments for further investigations. #39 might fix some, but at least the described warnings can be seen in the CI logs.

Some additional changes were needed to get the test examples working on x86 and Windows.
Maybe there is a good reason to use fixed address in test_serialization that I don't know, but it gives problems for x86 and ASan. I'm open for suggestions.

[Example run](https://github.com/bjosv/libco/actions/runs/4763162973)