### PR TITLE
Fix broken CI: Add missing package to apt-get install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
         run: |
           sudo dpkg --add-architecture i386
           sudo apt-get update -q -y
-          sudo apt-get install -y gcc-multilib g++-multilib valgrind libc6-dbg libc6-dbg:i386
+          sudo apt-get install -y gcc-multilib g++-multilib valgrind libc6-dbg libc6-dbg:i386 libgcc-s1:i386
       - name: Build
         working-directory: doc/examples
         run: |


### PR DESCRIPTION
CI jobs are broken, apparently due to changes by GitHub or the distros used in the CI jobs.

Adding an extra package to `apt-get install` command appears to fix the issue.