### PR TITLE
Add 32-bit PowerPC to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,39 @@ jobs:
             fi
             # test_timing not run with valgrind on qemu since it's very slow.
 
+  build-qemu-ppc:
+    name: ppc
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Prepare
+        run: |
+          sudo apt-get update -q -y
+          sudo apt-get install -y qemu binfmt-support qemu-user-static
+      - name: Register QEMU as executor via binfmt_misc
+        uses: addnab/docker-run-action@v3
+        with:
+          image: multiarch/qemu-user-static:register
+          options: --privileged
+      - name: Build and run tests in a PowerPC container
+        uses: addnab/docker-run-action@v3
+        with:
+          image: lpenz/debian-jessie-powerpc:latest
+          # Valgrind on Debian Jessie powerpc requires <= 8MB stack size to work.
+          # Set QEMUs stack size to 8MB since Github runners use 16MB default.
+          options: -v ${{ github.workspace }}:/work -e QEMU_STACK_SIZE=8388608
+          run: |
+            sed -i 's;http://deb.debian.org;http://archive.debian.org;' /etc/apt/sources.list
+            apt-get update -q -y
+            apt-get install -y --allow-unauthenticated build-essential valgrind
+            cd /work/doc/examples
+            ./build.sh
+            ./test_args
+            ./test_timing
+            # Serialization not supported
+            ./valgrind-wrapper.sh ./test_args
+            # test_timing not run with valgrind on qemu since it's very slow.
+
   build-posix:
     name: ${{ matrix.target }}
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,20 +66,18 @@ jobs:
           install: |
             apt-get update -q -y
             apt-get install -q -y --no-install-recommends build-essential valgrind
+          env: |
+            # Valgrind on arm will fail if the stack size is larger than 8MB.
+            # Set QEMUs stack size to 8MB since Github runners use 16MB default.
+            QEMU_STACK_SIZE: 8388608
           run: |
             cd doc/examples
             ./build.sh
             ./test_args
             ./test_timing
             ./test_serialization
-            if [ "${{ matrix.target }}" == "arm" ]; then
-              # "valgrind: I failed to allocate space for the application's stack"
-              ./valgrind-wrapper.sh --expect-failure ./test_args
-              ./valgrind-wrapper.sh --expect-failure ./test_serialization
-            else
-              ./valgrind-wrapper.sh ./test_args
-              ./valgrind-wrapper.sh --expect-failure ./test_serialization
-            fi
+            ./valgrind-wrapper.sh ./test_args
+            ./valgrind-wrapper.sh --expect-failure ./test_serialization
             # test_timing not run with valgrind on qemu since it's very slow.
 
   build-qemu-ppc:


### PR DESCRIPTION
Adds a CI job that runs a Debian 8.11 (Jessie) container via QEMU on 32-bit PowerPC.
This builds and tests libco when using the ppc-backend from `ppc.c`.
    
This setup is enabled by the `multiarch/qemu-user-static` container which registers `binfmt_misc` entries under the /proc filesystem to refer execution/interpretation to QEMU.
QEMU is run with max 8MB stack size since Valgrind aborts when using the Github-runners default size of 16MB.

This PR also includes a fix for Arm to make sure Valgrind can allocate stack space, which fixes current [behavior](https://github.com/higan-emu/libco/actions/runs/4892736309/jobs/8734852064#step:3:390).
This is also fixed by limiting the stack size to 8MB.

Other info:
- Jessie was the last Debian release supporting 32-bit PowerPC.
- https://en.wikipedia.org/wiki/Binfmt_misc
- https://github.com/multiarch/qemu-user-static
