### PR TITLE
Fix compilation on MSVC

### DIFF
--- a/amd64.c
+++ b/amd64.c
@@ -139,12 +139,13 @@ cothread_t co_derive(void* memory, unsigned int size, void (*entrypoint)(void)) 
 
   if((handle = (cothread_t)memory)) {
     unsigned long long stack_top = (unsigned long long)handle + size;
+    long long *p;
     stack_top -= 32;
     stack_top &= ~((unsigned long long) 15);
-    long long *p = (long long*)(stack_top);  /* seek to top of stack */
-    *--p = (long long)crash;                 /* crash if entrypoint returns */
-    *--p = (long long)entrypoint;            /* start of function */
-    *(long long*)handle = (long long)p;      /* stack pointer */
+    p = (long long*)(stack_top);         /* seek to top of stack */
+    *--p = (long long)crash;             /* crash if entrypoint returns */
+    *--p = (long long)entrypoint;        /* start of function */
+    *(long long*)handle = (long long)p;  /* stack pointer */
   }
 
   return handle;

--- a/settings.h
+++ b/settings.h
@@ -116,7 +116,10 @@
 #endif
 
 #if defined(_MSC_VER)
-  #define section(name) __declspec(allocate("." #name))
+  /* workaround for msvc preprocessor stringification behavior */
+  #define LIBCO_STRINGIFY(x) #x
+  #define LIBCO_TOSTRING(x) LIBCO_STRINGIFY(x)
+  #define section(name) __pragma(code_seg(LIBCO_TOSTRING("." #name))) __declspec(allocate(LIBCO_TOSTRING("." #name)))
 #elif defined(__APPLE__)
   #define section(name) __attribute__((section("__TEXT,__" #name)))
 #else

--- a/x86.c
+++ b/x86.c
@@ -95,12 +95,13 @@ cothread_t co_derive(void* memory, unsigned int size, void (*entrypoint)(void)) 
 
   if((handle = (cothread_t)memory)) {
     unsigned long stack_top = (unsigned long)handle + size;
+    long *p;
     stack_top -= 32;
     stack_top &= ~((unsigned long) 15);
-    long *p = (long*)(stack_top);  /* seek to top of stack */
-    *--p = (long)crash;            /* crash if entrypoint returns */
-    *--p = (long)entrypoint;       /* start of function */
-    *(long*)handle = (long)p;      /* stack pointer */
+    p = (long*)(stack_top);    /* seek to top of stack */
+    *--p = (long)crash;        /* crash if entrypoint returns */
+    *--p = (long)entrypoint;   /* start of function */
+    *(long*)handle = (long)p;  /* stack pointer */
   }
 
   return handle;


### PR DESCRIPTION
- Fix `section` macro in settings.h so it compiles on MSVC.
- Fix non-C89 compliant variable declaration in `co_derive`.

Tested on Visual Studio 2022 and Visual C++ 2008.