### PR TITLE
ci: MSVC should support putting co_swap_function in a section.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,7 +178,7 @@ jobs:
         working-directory: doc/examples
         run: |
           # __STDC__ required for `alignas` (or using /Za)
-          cl /I ../.. /D LIBCO_MPROTECT /Zc:__STDC__ /c ../../libco.c
+          cl /I ../.. /Zc:__STDC__ /c ../../libco.c
           cl /I ../.. test_args.cpp libco.obj
           cl /I ../.. test_timing.cpp libco.obj
           cl /I ../.. test_serialization.cpp libco.obj
@@ -199,7 +199,7 @@ jobs:
         working-directory: doc/examples
         run: |
           # __STDC__ required for `alignas` (or using /Za)
-          cl /I ../.. /D LIBCO_MPROTECT /Zc:__STDC__ /Folibco /c ../../fiber.c
+          cl /I ../.. /Zc:__STDC__ /Folibco /c ../../fiber.c
           cl /I ../.. test_args.cpp libco.obj
           cl /I ../.. test_timing.cpp libco.obj
           # Serialization not supported

--- a/settings.h
+++ b/settings.h
@@ -116,7 +116,10 @@
 #endif
 
 #if defined(_MSC_VER)
-  #define section(name) __declspec(allocate("." #name))
+  /* workaround for msvc preprocessor stringification behavior */
+  #define LIBCO_STRINGIFY(x) #x
+  #define LIBCO_TOSTRING(x) LIBCO_STRINGIFY(x)
+  #define section(name) __pragma(code_seg(LIBCO_TOSTRING("." #name))) __declspec(allocate(LIBCO_TOSTRING("." #name)))
 #elif defined(__APPLE__)
   #define section(name) __attribute__((section("__TEXT,__" #name)))
 #else


### PR DESCRIPTION
So we don't need to define LIBCO_MPROTECT on Windows.