### PR TITLE
ci: Force libco to be compiled (on Linux) in C89 mode.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Build
         working-directory: doc/examples
         run: |
-          cc ${{ matrix.flags }} -std=c89 -Wdeclaration-after-statement -I../.. -o libco.o -c ../../libco.c
+          cc ${{ matrix.flags }} -std=c89 -Wdeclaration-after-statement -Werror -I../.. -o libco.o -c ../../libco.c
           c++ ${{ matrix.flags }} -I../.. -c test_timing.cpp
           c++ ${{ matrix.flags }} -o test_timing libco.o test_timing.o
           c++ ${{ matrix.flags }} -I../.. -c test_args.cpp
@@ -223,7 +223,7 @@ jobs:
         env:
           FLAGS: -fsanitize=${{ matrix.sanitizer }} -fno-sanitize-recover=all -fno-omit-frame-pointer
         run: |
-          clang $FLAGS -std=c89 -Wdeclaration-after-statement -I../.. -o libco.o -c ../../libco.c
+          clang $FLAGS -std=c89 -Wdeclaration-after-statement -Werror -I../.. -o libco.o -c ../../libco.c
           clang++ $FLAGS -I../.. -c test_timing.cpp
           clang++ $FLAGS -o test_timing libco.o test_timing.o
           clang++ $FLAGS -I../.. -c test_args.cpp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Build
         working-directory: doc/examples
         run: |
-          cc ${{ matrix.flags }} -I../.. -o libco.o -c ../../libco.c
+          cc ${{ matrix.flags }} -std=c89 -Wdeclaration-after-statement -I../.. -o libco.o -c ../../libco.c
           c++ ${{ matrix.flags }} -I../.. -c test_timing.cpp
           c++ ${{ matrix.flags }} -o test_timing libco.o test_timing.o
           c++ ${{ matrix.flags }} -I../.. -c test_args.cpp
@@ -136,7 +136,7 @@ jobs:
         env:
           FLAGS: -O3 -fomit-frame-pointer
         run: |
-          cc ${{ matrix.defines }} $FLAGS -I../.. -o libco.o -c ../../${{ matrix.file }}
+          cc ${{ matrix.defines }} -std=c89 -Wdeclaration-after-statement $FLAGS -I../.. -o libco.o -c ../../${{ matrix.file }}
           c++ $FLAGS -I../.. -c test_timing.cpp
           c++ $FLAGS -o test_timing libco.o test_timing.o
           c++ $FLAGS -I../.. -c test_args.cpp
@@ -223,7 +223,7 @@ jobs:
         env:
           FLAGS: -fsanitize=${{ matrix.sanitizer }} -fno-sanitize-recover=all -fno-omit-frame-pointer
         run: |
-          clang $FLAGS -I../.. -o libco.o -c ../../libco.c
+          clang $FLAGS -std=c89 -Wdeclaration-after-statement -I../.. -o libco.o -c ../../libco.c
           clang++ $FLAGS -I../.. -c test_timing.cpp
           clang++ $FLAGS -o test_timing libco.o test_timing.o
           clang++ $FLAGS -I../.. -c test_args.cpp

--- a/aarch64.c
+++ b/aarch64.c
@@ -77,8 +77,9 @@ cothread_t co_derive(void* memory, unsigned int size, void (*entrypoint)(void)) 
 
   if((handle = (unsigned long*)memory)) {
     unsigned long stack_top = (unsigned long)handle + size;
+    unsigned long *p;
     stack_top &= ~((unsigned long) 15);
-    unsigned long *p = (unsigned long*)(stack_top);
+    p = (unsigned long*)(stack_top);
     handle[0]  = (unsigned long)p;           /* x16 (stack pointer) */
     handle[1]  = (unsigned long)entrypoint;  /* x30 (link register) */
     handle[12] = (unsigned long)p;           /* x29 (frame pointer) */

--- a/amd64.c
+++ b/amd64.c
@@ -139,9 +139,10 @@ cothread_t co_derive(void* memory, unsigned int size, void (*entrypoint)(void)) 
 
   if((handle = (cothread_t)memory)) {
     unsigned long long stack_top = (unsigned long long)handle + size;
+    long long *p;
     stack_top -= 32;
     stack_top &= ~((unsigned long long) 15);
-    long long *p = (long long*)(stack_top);  /* seek to top of stack */
+    p = (long long*)(stack_top);             /* seek to top of stack */
     *--p = (long long)crash;                 /* crash if entrypoint returns */
     *--p = (long long)entrypoint;            /* start of function */
     *(long long*)handle = (long long)p;      /* stack pointer */

--- a/arm.c
+++ b/arm.c
@@ -53,8 +53,9 @@ cothread_t co_derive(void* memory, unsigned int size, void (*entrypoint)(void)) 
 
   if((handle = (unsigned long*)memory)) {
     unsigned long stack_top = (unsigned long)handle + size;
+    unsigned long *p;
     stack_top &= ~((unsigned long) 15);
-    unsigned long *p = (unsigned long*)(stack_top);
+    p = (unsigned long*)(stack_top);
     handle[8] = (unsigned long)p;
     handle[9] = (unsigned long)entrypoint;
   }

--- a/doc/examples/build.sh
+++ b/doc/examples/build.sh
@@ -1,4 +1,4 @@
-cc -O3 -fomit-frame-pointer -std=c89 -Wdeclaration-after-statement -I../.. -o libco.o -c ../../libco.c
+cc -O3 -fomit-frame-pointer -std=c89 -Wdeclaration-after-statement -Werror -I../.. -o libco.o -c ../../libco.c
 c++ -O3 -fomit-frame-pointer -I../.. -c test_timing.cpp
 c++ -O3 -fomit-frame-pointer -o test_timing libco.o test_timing.o
 c++ -O3 -fomit-frame-pointer -I../.. -c test_args.cpp

--- a/doc/examples/build.sh
+++ b/doc/examples/build.sh
@@ -1,4 +1,4 @@
-cc -O3 -fomit-frame-pointer -I../.. -o libco.o -c ../../libco.c
+cc -O3 -fomit-frame-pointer -std=c89 -Wdeclaration-after-statement -I../.. -o libco.o -c ../../libco.c
 c++ -O3 -fomit-frame-pointer -I../.. -c test_timing.cpp
 c++ -O3 -fomit-frame-pointer -o test_timing libco.o test_timing.o
 c++ -O3 -fomit-frame-pointer -I../.. -c test_args.cpp

--- a/ppc.c
+++ b/ppc.c
@@ -261,9 +261,9 @@ static const uint32_t libco_ppc_code[1024] = {
 #endif
 
 static uint32_t* co_derive_(void* memory, unsigned size, uintptr_t entry) {
-  (void)entry;
-
   uint32_t* t = (uint32_t*)memory;
+
+  (void)entry;
 
   #if LIBCO_PPCDESC
   if(t) {
@@ -327,9 +327,9 @@ cothread_t co_derive(void* memory, unsigned int size, void (*entry_)(void)) {
 }
 
 static uint32_t* co_create_(unsigned size, uintptr_t entry) {
-  (void)entry;
-
   uint32_t* t = (uint32_t*)LIBCO_MALLOC(size);
+
+  (void)entry;
 
   #if LIBCO_PPCDESC
   if(t) {

--- a/sjlj.c
+++ b/sjlj.c
@@ -43,9 +43,10 @@ cothread_t co_active(void) {
 }
 
 cothread_t co_derive(void* memory, unsigned int size, void (*coentry)(void)) {
+  cothread_struct* thread;
   if(!co_running) co_running = &co_primary;
 
-  cothread_struct* thread = (cothread_struct*)memory;
+  thread = (cothread_struct*)memory;
   memory = (unsigned char*)memory + sizeof(cothread_struct);
   size -= sizeof(cothread_struct);
   if(thread) {
@@ -87,9 +88,10 @@ cothread_t co_derive(void* memory, unsigned int size, void (*coentry)(void)) {
 }
 
 cothread_t co_create(unsigned int size, void (*coentry)(void)) {
+  cothread_struct* thread;
   if(!co_running) co_running = &co_primary;
 
-  cothread_struct* thread = (cothread_struct*)malloc(sizeof(cothread_struct));
+  thread = (cothread_struct*)malloc(sizeof(cothread_struct));
   if(thread) {
     struct sigaction handler;
     struct sigaction old_handler;

--- a/sjlj.c
+++ b/sjlj.c
@@ -3,13 +3,16 @@
   for SJLJ on other systems, one would want to rewrite springboard() and co_create() and hack the jmb_buf stack pointer.
 */
 
+/* for sigsetjmp(), sigjmp_buf, and stack_t */
+#define _POSIX_C_SOURCE 200809L
+/* for SA_ONSTACK */
+#define _XOPEN_SOURCE 600
+
 #define LIBCO_C
 #include "libco.h"
 #include "settings.h"
 #include "valgrind.h"
 
-#define _BSD_SOURCE
-#define _XOPEN_SOURCE 500
 #include <stdlib.h>
 #include <signal.h>
 #include <setjmp.h>

--- a/ucontext.c
+++ b/ucontext.c
@@ -10,13 +10,12 @@
   use this library only as a *last resort*
 */
 
+#define _POSIX_C_SOURCE 200112L
 #define LIBCO_C
 #include "libco.h"
 #include "settings.h"
 #include "valgrind.h"
 
-#define _BSD_SOURCE
-#define _XOPEN_SOURCE 500
 #include <stdlib.h>
 #include <ucontext.h>
 

--- a/ucontext.c
+++ b/ucontext.c
@@ -32,8 +32,9 @@ cothread_t co_active(void) {
 }
 
 cothread_t co_derive(void* memory, unsigned int heapsize, void (*coentry)(void)) {
+  ucontext_t* thread;
   if(!co_running) co_running = &co_primary;
-  ucontext_t* thread = (ucontext_t*)memory;
+  thread = (ucontext_t*)memory;
   memory = (unsigned char*)memory + sizeof(ucontext_t);
   heapsize -= sizeof(ucontext_t);
   if(thread) {
@@ -50,8 +51,9 @@ cothread_t co_derive(void* memory, unsigned int heapsize, void (*coentry)(void))
 }
 
 cothread_t co_create(unsigned int heapsize, void (*coentry)(void)) {
+  ucontext_t* thread;
   if(!co_running) co_running = &co_primary;
-  ucontext_t* thread = (ucontext_t*)malloc(sizeof(ucontext_t));
+  thread = (ucontext_t*)malloc(sizeof(ucontext_t));
   if(thread) {
     if((!getcontext(thread) && !(thread->uc_stack.ss_sp = 0)) && (thread->uc_stack.ss_sp = malloc(heapsize))) {
       thread->uc_link = co_running;

--- a/x86.c
+++ b/x86.c
@@ -95,9 +95,10 @@ cothread_t co_derive(void* memory, unsigned int size, void (*entrypoint)(void)) 
 
   if((handle = (cothread_t)memory)) {
     unsigned long stack_top = (unsigned long)handle + size;
+    long *p;
     stack_top -= 32;
     stack_top &= ~((unsigned long) 15);
-    long *p = (long*)(stack_top);  /* seek to top of stack */
+    p = (long*)(stack_top);  /* seek to top of stack */
     *--p = (long)crash;            /* crash if entrypoint returns */
     *--p = (long)entrypoint;       /* start of function */
     *(long*)handle = (long)p;      /* stack pointer */


### PR DESCRIPTION
This should help us avoid changes that break C89 compatibility.